### PR TITLE
fix #1  - add uniqueness into import-id

### DIFF
--- a/__openerp__.py
+++ b/__openerp__.py
@@ -3,7 +3,7 @@
     'name': 'Account Bank Statement Import OKO Finland',
     'author':'Oy Netitbe Ltd / Eino Mäkitalo',
     'category': 'Accounting & Finance',
-    'version': '9.0.0.0.1',
+    'version': '9.0.0.0.2',
     'depends': ['account_bank_statement_import'],
     'description': """OKO Bank simple bank statement in csv format""",
     'data': [

--- a/account_bank_statement_import.py
+++ b/account_bank_statement_import.py
@@ -8,6 +8,7 @@ from openerp.addons.base.res.res_bank import sanitize_account_number
 from decimal import Decimal
 import openerp.addons.decimal_precision as dp
 import hashlib
+import sys
 
 import logging
 _logger = logging.getLogger(__name__)

--- a/account_bank_statement_import.py
+++ b/account_bank_statement_import.py
@@ -7,6 +7,7 @@ from openerp.exceptions import UserError
 from openerp.addons.base.res.res_bank import sanitize_account_number
 from decimal import Decimal
 import openerp.addons.decimal_precision as dp
+import hashlib
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -64,6 +65,7 @@ class AccountBankStatementImport(models.TransientModel):
         if not self.__check_oko(data_file):
             return super(AccountBankStatementImport, self)._parse_file(data_file)            
         
+        
         transactions=[]
         mindate="9999-99-99"
         maxdate="0000-00-00"
@@ -95,12 +97,18 @@ class AccountBankStatementImport(models.TransientModel):
                     memo='-'
                 if len(other_part.strip())==0:
                     other_part=''
+                hashMD5 = hashlib.md5()  #known security issues with md5 but simple enough to provide uniqueness for OKO bank archiveid duplicates
+                if sys.version_info.major>2:
+                    hashMD5.update(bytes(row),"iso8859-15")
+                else:
+                    hashMD5.update(row)
+                extra_uniqueness= hashMD5.hexdigest()
                 oneval={
                     'sequence': linenum, # added for sequence?
                     'name':other_part,
                     'date':accdate,
                     'amount': amountEUR,
-                    'unique_import_id':archiveid+"-"+accdate,
+                    'unique_import_id':archiveid+"-"+extra_uniqueness,
                     'account_number':acc_num,
                     'note':memo,
                     'partner_name':other_part,


### PR DESCRIPTION
No we calculate md5 hash to add uniqueness when importing OKO account statements where archive id is same
